### PR TITLE
Update start_discovery.sh

### DIFF
--- a/start_discovery.sh
+++ b/start_discovery.sh
@@ -4,4 +4,4 @@ do
   echo "waiting for certificates."
   sleep 1
 done
-${USER_HOME}/server/discosrv -listen=":${DISCO_PORT}" -db-dir="${USER_HOME}/db/discosrv.db" -cert="${USER_HOME}/certs/cert.pem" -key="${USER_HOME}/certs/key.pem" ${DISCO_OPTS}
+${USER_HOME}/server/discosrv --listen=":${DISCO_PORT}" --db-dir="${USER_HOME}/db/discosrv.db" --cert="${USER_HOME}/certs/cert.pem" --key="${USER_HOME}/certs/key.pem" ${DISCO_OPTS}


### PR DESCRIPTION
Parameters of discoserv changed, resulting the script to throw errors during startup:
```     
discosrv: error: unknown flag -l, did you mean one of "-h", "-d", "-v"?
[TIME] WARN exited: discovery (exit status 80; not expected)
[TIME] INFO gave up: discovery entered FATAL state, too many start retries too quickly
```